### PR TITLE
Convert new and old text to trimmed strings to prevent JS display bug

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -67,7 +67,7 @@ class filter_jmol extends moodle_text_filter {
         $search = $search1.$search2;
         // Bigscreen loaded here, rather than in child iframe, to support Internet Explorer.
         $newtext = preg_replace_callback($search, 'filter_jmol_replace_callback', $text);
-        if (($newtext !== $text) && !isset($jmolenabled)) {
+        if ((strval(trim($newtext)) !== strval(trim($text))) && !isset($jmolenabled)) {
             $jmolenabled = true;
             $newtext = '
             <script src="'.$wwwroot.'/filter/jmol/js/jsmol/jquery/jquery.min.js"></script>


### PR DESCRIPTION
On Moodle 3.9+ we're seeing a bug where JS code is output to questionnaire reports because of type differences when test are performed in the JMol filter. This fix resolves the bug by comparing new and old text values to trimmed strings before comparison.